### PR TITLE
[hold] feat: support caching of token

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,38 @@ The current supported options and their defaults are:
 
 ```
   -audience string
-        Audience the JWT token will be for (default "sts.amazonaws.com")
+    	Audience the JWT token will be for (default "sts.amazonaws.com")
+  -cache-dir string
+    	cache directory to use for storing the IAM credentials; if set the process would check cache before issuing a new request
   -role-arn string
-        ARN of the role to assume
+    	ARN of the role to assume
   -role-session-name string
-        Role session name to use (default "spiffe-aws2-credential-process")
+    	Role session name to use (default "spiffe-aws2-credential-process")
   -socketPath string
-        Socket path to talk to spiffe agent (default "unix:/tmp/agent.sock")
+    	Socket path to talk to spiffe agent (default "unix:/tmp/agent.sock")
+  -spiffe-id string
+    	Request a specific SPIFFE ID (instead of all SPIFFE IDs)
   -timeout duration
-        timeout waiting for the process to finish (default 10s)
+    	timeout waiting for the process to finish (default 10s)
 ```
+
+# AWS IAM Credential Cache
+
+When performing an `assume-role-with-web-identity` operation, the
+AWS Security Token Service (STS) must retrieve signing keys for Spiffe ID
+verification, which can cause problems when making frequent requests. This is
+because the STS service fetches the keys every time it's called if the keys
+are not cached, and it has a low request limit that can lead to errors like this:
+
+```
+Unable to perform assume-role-with-web-identity: InvalidIdentityToken: Couldn't retrieve verification key from your identity provider,  please reference AssumeRoleWithWebIdentity documentation for requirements\n\tstatus code: 400
+```
+
+If you specify the -cache-dir argument, the command will cache the STS token
+in the directory you specified. It will store the STS token in a local file
+and use it instead of making a new call to AWS STS service in future invocations.
+The token stored on the file system is at risk if unauthorized access happens.
+
+Note that the command will treat a token as expired _5 minutes_ before its
+actual expiration time to allow the process to function without having to
+immediately deal with expired token.

--- a/main.go
+++ b/main.go
@@ -79,8 +79,8 @@ func (c *Cache) filenameByRole(role string) string {
 }
 
 func (c *Cache) Get(role string) (*Output, bool) {
-	fn := path.Join(c.Dir, c.filenameByRole(role))
-	if f, err := os.Open(fn); err != nil {
+	fp := path.Join(c.Dir, c.filenameByRole(role))
+	if f, err := os.Open(fp); err != nil {
 		return nil, false
 	} else {
 
@@ -104,12 +104,19 @@ func (c *Cache) Get(role string) (*Output, bool) {
 }
 
 func (c *Cache) Set(role string, output *Output) error {
-	fn := path.Join(c.Dir, c.filenameByRole(role))
+	fn := c.filenameByRole(role)
+	fp := path.Join(c.Dir, fn)
 	if bytes, err := json.Marshal(output); err != nil {
 		return err
 	} else {
-		if err := os.WriteFile(fn, bytes, 0600); err != nil {
+		if f, err := os.CreateTemp(c.Dir, fn+"-"); err != nil {
 			return err
+		} else {
+			f.Close()
+			if err := os.WriteFile(f.Name(), bytes, 0600); err != nil {
+				return err
+			}
+			os.Rename(f.Name(), fp)
 		}
 
 		return nil

--- a/main.go
+++ b/main.go
@@ -89,15 +89,15 @@ func (c *Cache) Get(role string) (*Output, bool) {
 			output := Output{}
 			if err := json.Unmarshal(bytes, &output); err != nil {
 				return nil, false
-			} else {
-				// check expiration
-				if tm, err := time.Parse(time.RFC3339, output.Expiration); err == nil && tm.After(time.Now().Add(REFRESH_HEAD_ROOM)) {
-					return &output, true
-				}
-
-				// don't use cache
-				return nil, false
 			}
+
+			// check expiration
+			if tm, err := time.Parse(time.RFC3339, output.Expiration); err == nil && tm.After(time.Now().Add(REFRESH_HEAD_ROOM)) {
+				return &output, true
+			}
+
+			// don't use cache
+			return nil, false
 		}
 	}
 }
@@ -156,7 +156,7 @@ func main() {
 					log.Warn(err)
 				}
 				fmt.Print(string(output))
-				os.Exit(0)
+				return
 			}
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -193,7 +193,9 @@ func main() {
 
 	// update cache
 	if cache_dir != "" {
-		if cache, err := NewCache(cache_dir); err == nil {
+		if cache, err := NewCache(cache_dir); err != nil {
+			log.Warnf("Unable to create cache: %v", err)
+		} else {
 			if err := cache.Set(role_arn, &extractedCred); err != nil {
 				log.Warn(err)
 			}

--- a/main.go
+++ b/main.go
@@ -197,7 +197,7 @@ func main() {
 			log.Warnf("Unable to create cache: %v", err)
 		} else {
 			if err := cache.Set(role_arn, &extractedCred); err != nil {
-				log.Warn(err)
+				log.Warnf("Unable to update cache: %v", err)
 			}
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -82,23 +82,23 @@ func (c *Cache) Get(role string) (*Output, bool) {
 	fn := path.Join(c.Dir, c.filenameByRole(role))
 	if f, err := os.Open(fn); err != nil {
 		return nil, false
+	}
+
+	if bytes, err := io.ReadAll(f); err != nil {
+		return nil, false
 	} else {
-		if bytes, err := io.ReadAll(f); err != nil {
-			return nil, false
-		} else {
-			output := Output{}
-			if err := json.Unmarshal(bytes, &output); err != nil {
-				return nil, false
-			}
-
-			// check expiration
-			if tm, err := time.Parse(time.RFC3339, output.Expiration); err == nil && tm.After(time.Now().Add(REFRESH_HEAD_ROOM)) {
-				return &output, true
-			}
-
-			// don't use cache
+		output := Output{}
+		if err := json.Unmarshal(bytes, &output); err != nil {
 			return nil, false
 		}
+
+		// check expiration
+		if tm, err := time.Parse(time.RFC3339, output.Expiration); err == nil && tm.After(time.Now().Add(REFRESH_HEAD_ROOM)) {
+			return &output, true
+		}
+
+		// don't use cache
+		return nil, false
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -64,9 +64,8 @@ func NewCache(dir string) (*Cache, error) {
 	fn := path.Join(dir, "validate")
 	if _, err := os.Create(fn); err != nil {
 		return nil, err
-	} else {
-		os.Remove(fn)
 	}
+	os.Remove(fn)
 
 	return &Cache{
 		Dir: dir,
@@ -94,10 +93,10 @@ func (c *Cache) Get(role string) (*Output, bool) {
 				// check expiration
 				if tm, err := time.Parse(time.RFC3339, output.Expiration); err == nil && tm.After(time.Now().Add(REFRESH_HEAD_ROOM)) {
 					return &output, true
-				} else {
-					// don't use cache
-					return nil, false
 				}
+
+				// don't use cache
+				return nil, false
 			}
 		}
 	}
@@ -110,9 +109,9 @@ func (c *Cache) Set(role string, output *Output) error {
 	} else {
 		if err := os.WriteFile(fn, bytes, 0600); err != nil {
 			return err
-		} else {
-			return nil
 		}
+
+		return nil
 	}
 }
 


### PR DESCRIPTION

STS can't handle rapid `assume-role-with-web-identity` so caching of STS token may be required.  This should only be used for use cases where client can't be change to support token caching natively, and risk of cached token in local filesystem is mitigated.